### PR TITLE
unnecessary pull 

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -10,7 +10,6 @@
 		
 		// Loop the pictures
 		for( var i = 0, il = ps.length; i < il; i++ ){
-			var picImg = null;
 			if( ps[ i ].getAttribute( "data-picture" ) !== null ){
 
 				var sources = ps[ i ].getElementsByTagName( "div" ),
@@ -26,7 +25,7 @@
 				}
 
 			// Find any existing img element in the picture element
-			picImg = ps[ i ].getElementsByTagName( "img" )[ 0 ];
+			var picImg = ps[ i ].getElementsByTagName( "img" )[ 0 ];
 
 			if( matches.length ){			
 				if( !picImg ){


### PR DESCRIPTION
There is no need to assign picImg outside of the if branch.

Somewhere between https://github.com/scottjehl/picturefill/commit/5cfe8c7ceeed402b77069e5ba6e2abdfa641c6f7 and https://github.com/scottjehl/picturefill/commit/c839311a457f81675d33a0faa5d02153fd4778bc the second else if was removed, but it doesn't show up in the diff.  I had checked out and submitted a patch for the https://github.com/scottjehl/picturefill/commit/c839311a457f81675d33a0faa5d02153fd4778bc version, the current version at the time.  The better fix is to remove the second else if and it seems like it was there in the first place because of a bad merge.
