### PR TITLE
Added note on requirement for browser prefixes for HD images

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Notes on the markup above...
 
 Picturefill natively supports HD(Retina) image replacement.  While numerous other solutions exist, picturefill has the added benefit of performance for the user in only getting served one image.
 
-* The `data-media` attribute supports compound media queries, allowing for very specific behaviors to emerge.  For example, a `data-media="(min-width: 400px) and (min-device-pixel-ratio: 2.0)` attribute can be used to serve a higher resolution version of the source instead of a standard definition image.
+* The `data-media` attribute supports [compound media queries](https://developer.mozilla.org/en-US/docs/CSS/Media_queries), allowing for very specific behaviors to emerge.  For example, a `data-media="(min-width: 400px) and (min-device-pixel-ratio: 2.0)` attribute can be used to serve a higher resolution version of the source instead of a standard definition image. Note you currently also need to add the `-webkit-min-device-pixel-ratio` prefix (e.g. for iOS devices).
 
 ```html
 	<div data-picture data-alt="A giant stone face at The Bayon temple in Angkor Thom, Cambodia">


### PR DESCRIPTION
`min-device-pixel-ratio` alone isn't enough for the iPhone/iPad (in iOS 5.1).  I've added a note but left the prefix-less code sample as it is to avoid the compound stuff with the widths becoming too confusing.
