### PR TITLE
Safari 4.0 compatibility fix

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -28,7 +28,7 @@
 			var picImg = ps[ i ].getElementsByTagName( "img" )[ 0 ];
 
 			if( matches.length ){			
-				if( !picImg ){
+				if( !picImg || picImg.parentNode.tagName.toUpperCase() == 'NOSCRIPT' ){
 					picImg = w.document.createElement( "img" );
 					picImg.alt = ps[ i ].getAttribute( "data-alt" );
 					ps[ i ].appendChild( picImg );


### PR DESCRIPTION
Safari 4.0 returns the &lt;img> inside the &lt;noscript> tag, which 
results in a new &lt;img> not being appended to the &lt;div>. This fix
ensures that these images are ignored.
