### PR TITLE
Added onerror support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, `picturefill.js` compresses to around 498bytes (~0.5kb), after minify
 Mark up your responsive images like this.
 
 ```html
-	<div data-picture data-alt="A giant stone face at The Bayon temple in Angkor Thom, Cambodia" data-onerror="imgError">
+	<div data-picture data-alt="A giant stone face at The Bayon temple in Angkor Thom, Cambodia" onerror="imgError">
 		<div data-src="small.jpg"></div>
 		<div data-src="medium.jpg"     data-media="(min-width: 400px)"></div>
 		<div data-src="large.jpg"      data-media="(min-width: 800px)"></div>

--- a/picturefill.js
+++ b/picturefill.js
@@ -37,13 +37,13 @@
 
 					if ( picImg.addEventListener ){
 						picImg.addEventListener( "error" , function(){
-							return window[pc.getAttribute("data-onerror")](picImg);
+							return window[pc.getAttribute("onerror")](picImg);
 						}
 						);
 					}
 					else if ( picImg.attachEvent ) {
 						picImg.attachEvent( "error" , function(){
-							return window[pc.getAttribute("data-onerror")](picImg);
+							return window[pc.getAttribute("onerror")](picImg);
 						}
 						);
 					}


### PR DESCRIPTION
It's a pain to diagnose broken images without an onerror state. So added the `data-onerror` attribute to `[data-picture]`. It just passes an onerror function to picImg.
