### PR TITLE
Add support for wrapping image in anchor element (different solution)

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -31,7 +31,7 @@
 				if( !picImg ){
 					picImg = w.document.createElement( "img" );
 					picImg.alt = ps[ i ].getAttribute( "data-alt" );
-					ps[ i ].appendChild( picImg );
+					sources[ 0 ].parentNode.appendChild( picImg );
 				}
 				
 				picImg.src =  matches.pop().getAttribute( "data-src" );


### PR DESCRIPTION
Instead of the solution proposed in PR #52 I propose adding the picImg as a sibling of the source elements.

That way the page is free to do whatever wrapping of elements needed.
