### PR TITLE
Use querySelectorAll if available

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -19,6 +19,7 @@
 					ps.push(psTemp[ i ])
 				}
 			}
+			psTemp = null;
 		}
 		
 		// Loop the pictures


### PR DESCRIPTION
Instead of looking through the whole DOM for all div tags and then trimming those down to the ones with the "data-picture" attribute, this uses the browser-provided querySelectorAll function, which should be much faster.
