### PR TITLE
Add suport to "data-width" in <span> elements

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -32,9 +32,23 @@
 				if( !picImg || picImg.parentNode.nodeName === "NOSCRIPT" ){
 					picImg = w.document.createElement( "img" );
 					picImg.alt = ps[ i ].getAttribute( "data-alt" );
+
+                    if( ps[ i ].getAttribute( "data-width" ) ) {
+                        picImg.width = ps[ i ].getAttribute( "data-width" );
+                    }
+                    else {
+                        picImg.removeAttribute( "width" );
+                    }
 				}
 
 				picImg.src =  matchedEl.getAttribute( "data-src" );
+                if( matchedEl.getAttribute( "data-width" ) ) {
+                    picImg.width = matchedEl.getAttribute( "data-width" );
+                }
+                else {
+                    picImg.removeAttribute( "width" );
+                }
+
 				matchedEl.appendChild( picImg );
 			}
 			else if( picImg ){


### PR DESCRIPTION
According https://github.com/scottjehl/picturefill/issues/87 issue, some
people miss the feature of specify width of generated image. This pull
request add the capability of do this by specifying a `data-with` attr
in the respective `<span>`s which are supposed to have this.

The README.md wasn't updated because I don't knew in what places to put
the infos to not to lose the "line" of the explanations.

PS: Only now I saw the indentation problem in the new code. Anyway, I hope this help.
