### PR TITLE
Check if picImg is already a child of matchedEl

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -33,6 +33,10 @@
 					picImg = w.document.createElement( "img" );
 					picImg.alt = ps[ i ].getAttribute( "data-alt" );
 				}
+				else if( matchedEl === picImg.parentNode ){
+					// Skip further actions if the correct image is already in place
+					continue;
+				}
 
 				picImg.src =  matchedEl.getAttribute( "data-src" );
 				matchedEl.appendChild( picImg );


### PR DESCRIPTION
In working on some local modifications to picturefill (which I hope to submit as a PR at a later time), I noticed some jerkiness when resizing the page. I found that the end action where the code changes the `src` and re-appends the element were the source of the problem.

Since these actions are unnecessary if we are not changing the image, this change adds a `continue` if the image's parent node is already `matchedEl`.
