### PR TITLE
Add temp fix for IE attribute issue

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -40,12 +40,8 @@
 
 				picImg.src =  matchedEl.getAttribute( "data-src" );
 				matchedEl.appendChild( picImg );
-				if(picImg.getAttribute("width")){
-					picImg.removeAttribute("width");
-				}
-				if(picImg.getAttribute("height")){
-					picImg.removeAttribute("height");
-				}
+				picImg.removeAttribute("width");
+				picImg.removeAttribute("height");
 			}
 			else if( picImg ){
 				picImg.parentNode.removeChild( picImg );


### PR DESCRIPTION
A messy fix which removes the width and height attributes automatically added when img element is created in IE < 9
