### PR TITLE
Always update img alt attribute

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -31,7 +31,6 @@
 				var matchedEl = matches.pop();
 				if( !picImg || picImg.parentNode.nodeName === "NOSCRIPT" ){
 					picImg = w.document.createElement( "img" );
-					picImg.alt = ps[ i ].getAttribute( "data-alt" );
 				}
 				else if( matchedEl === picImg.parentNode ){
 					// Skip further actions if the correct image is already in place
@@ -39,6 +38,7 @@
 				}
 
 				picImg.src =  matchedEl.getAttribute( "data-src" );
+				picImg.alt = ps[ i ].getAttribute( "data-alt" );
 				matchedEl.appendChild( picImg );
 			}
 			else if( picImg ){


### PR DESCRIPTION
Image alt attribute is now always set, not just when the img element is first created. This is useful when picturefill is being called to respond to changed data-src attributes, instead of just a changed viewport size.
