### PR TITLE
Delayed resize, complete event

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ browsers, you might consider using conditional comments, like this:
 If picturefill is deferred until after load is fired, images will not load unless the browser window is resized.
 Picturefill is intentionally exposed to the global space, in the unusual situation where you might want to defer loading of picturefill you can explicitly call window.picturefill().
 
+### Complete Callback
+
+Picturefill triggers a `picurefill:complete` callback on the document object when it has finished all picturefills. For example, you may use it as follows:
+
+```javascript
+document.addEventListener('picturefill:complete', function() {
+  // Do something here
+}, false);
+```
+
 ## Support
 
 Picturefill supports a broad range of browsers and devices (there are currently no known unsupported browsers), provided that you stick with the markup conventions provided.

--- a/picturefill.js
+++ b/picturefill.js
@@ -24,35 +24,50 @@
 					}
 				}
 
-			// Find any existing img element in the picture element
-			var picImg = ps[ i ].getElementsByTagName( "img" )[ 0 ];
+				// Find any existing img element in the picture element
+				var picImg = ps[ i ].getElementsByTagName( "img" )[ 0 ];
 
-			if( matches.length ){
-				var matchedEl = matches.pop();
-				if( !picImg || picImg.parentNode.nodeName === "NOSCRIPT" ){
-					picImg = w.document.createElement( "img" );
-					picImg.alt = ps[ i ].getAttribute( "data-alt" );
-				}
-				else if( matchedEl === picImg.parentNode ){
-					// Skip further actions if the correct image is already in place
-					continue;
-				}
+				if( matches.length ){
+					var matchedEl = matches.pop();
+					if( !picImg || picImg.parentNode.nodeName === "NOSCRIPT" ){
+					  picImg = w.document.createElement( "img" );
+					  picImg.alt = ps[ i ].getAttribute( "data-alt" );
+					}
+					else if( matchedEl === picImg.parentNode ){
+					  // Skip further actions if the correct image is already in place
+					  continue;
+					}
 
-				picImg.src =  matchedEl.getAttribute( "data-src" );
-				matchedEl.appendChild( picImg );
-				picImg.removeAttribute("width");
-				picImg.removeAttribute("height");
-			}
-			else if( picImg ){
-				picImg.parentNode.removeChild( picImg );
+					picImg.src =  matchedEl.getAttribute( "data-src" );
+					matchedEl.appendChild( picImg );
+					picImg.removeAttribute("width");
+					picImg.removeAttribute("height");
+				}
+				else if( picImg ){
+					picImg.parentNode.removeChild( picImg );
+				}
 			}
 		}
+		if( picEvent ){
+			document.dispatchEvent(picEvent);
 		}
 	};
 
+	// Create custom event
+	if( document.createEvent ){
+		var picEvent = document.createEvent('Event');
+		picEvent.initEvent('picturefill:complete',true,true);
+	}
+
 	// Run on resize and domready (w.load as a fallback)
 	if( w.addEventListener ){
-		w.addEventListener( "resize", w.picturefill, false );
+		// Call resize only once
+		w.addEventListener( "resize", function() {
+			w.clearTimeout(w.picTimer);
+			w.picTimer = setTimeout(function() {
+			  w.picturefill();
+			}, 100);
+		}, false );
 		w.addEventListener( "DOMContentLoaded", function(){
 			w.picturefill();
 			// Run once only


### PR DESCRIPTION
I've added code to trigger an event on complete. This provides a solution for many of your pull requests, as people can add their own code to transfer id, class, data attributes, lazy loading of large images, or do whatever. 

Since it was built into the script, I've also added a 100ms timer delay to the resize event so it isn't called 50 times in a row for browsers like Chrome. 

There are not as many changes as there appears to be. I reset the tab indentation for several lines.
