### PR TITLE
Added link in readme to AngularJS directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,6 @@ Picturefill is intentionally exposed to the global space, in the unusual situati
 
 Picturefill supports a broad range of browsers and devices (there are currently no known unsupported browsers), provided that you stick with the markup conventions provided.
 
+### AngularJS 
+
+Picturefill can be implementing in AngularJS apps using the [angular-picturefill directive](https://github.com/tinacious/angular-picturefill).


### PR DESCRIPTION
A link to the AngularJS directive for Picturefill I developed was inserted under the Support section of the readme. The directive can be downloaded and installed with Bower and Grunt, downloading and installing the original package. The project page links to a working demo of an Angular implementation.
