### PR TITLE
Use source variable when getting media attribute.

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -175,7 +175,7 @@
             // and add them to matches
             for (var j=0, slen = sources.length; j < slen; j++) {
                 var source = sources[j];
-                var media = sources[j].getAttribute( "media" );
+                var media = source.getAttribute( "media" );
 
                 // if source does not have a srcset attribute, skip
                 if (!source.hasAttribute('srcset')) {


### PR DESCRIPTION
When retrieving the media attribute from a source, use the source variable on the line above rather than using sources[j] again.
