### PR TITLE
Only add img[alt] when [data-alt] exists

### DIFF
--- a/picturefill.js
+++ b/picturefill.js
@@ -31,7 +31,10 @@
 					var matchedEl = matches.pop();
 					if( !picImg || picImg.parentNode.nodeName === "NOSCRIPT" ){
 						picImg = w.document.createElement( "img" );
-						picImg.alt = ps[ i ].getAttribute( "data-alt" );
+						var alt = ps[ i ].getAttribute( "data-alt" );
+						if (alt !== null) {
+							picImg.alt = alt;
+						}
 					}
 					else if( matchedEl === picImg.parentNode ){
 						// Skip further actions if the correct image is already in place


### PR DESCRIPTION
Fix a bug where, when the element specified by [data-picture] did not have a [data-alt] attribute, the generated image element would have an [alt] attribute set to the string value "null".

```
<span data-picture> → <img alt="null" src="...">
```

Now, the following hold:

```
<span data-picture> → <img src="...">
<span data-picture data-alt=""> → <img alt="" src="...">
<span data-picture data-alt="alt text"> → <img alt="alt text" src="...">
```
