### PR TITLE
Set source on the inner `img` `srcset` attribute if supported

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -170,7 +170,11 @@
 			candidate = sortedImgCandidates[ l ];
 			if ( candidate.resolution >= pf.getDpr() ) {
 				if ( !pf.endsWith( picImg.src, candidate.url ) ) {
-					picImg.src = candidate.url;
+					if( picImg.srcset === undefined ) {
+						picImg.src = candidate.url;
+					} else {
+						picImg.srcset = candidate.url;
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
This prevents anything specified in the `srcset` attribute from natively overriding a selected source set in the `src`.
