### PR TITLE
fix candidate selection

### DIFF
--- a/dist/picturefill.js
+++ b/dist/picturefill.js
@@ -281,9 +281,9 @@ window.matchMedia || (window.matchMedia = function() {
 	};
 
 	pf.applyBestCandidate = function( candidates, picImg ) {
-		candidates.sort( pf.descendingSort );
-		var candidate, bestCandidate = pop(candidates);
-		for ( var l=1; l < candidates.length; l++ ) {
+		candidates.sort( pf.ascendingSort );
+		var candidate, bestCandidate = candidates.pop();
+		for ( var l=0; l < candidates.length; l++ ) {
 			candidate = candidates[ l ];
 			if (candidate.resolution >= pf.getDpr()) {
 				bestCandidate = candidate;
@@ -299,7 +299,7 @@ window.matchMedia || (window.matchMedia = function() {
 	};
 
 	pf.ascendingSort = function( a, b ) {
-		return b.resolution - a.resolution;
+		return a.resolution - b.resolution;
 	};
 
 	/*


### PR DESCRIPTION
previous ascendingSort() wasn’t doing much, since not returning -1 when
resolution ‘a’ was smaller than that of ‘b’. I fixed this ( - instead
of >) but also resorted to ascending sorting.

The logic now goes that we start with the highest resolution available,
then go down gradually until we find the last one that is just above the
Dpr. This solves the situation where all available images are below Dpr
(previously the lowest candidate would have been served, now the
highest is being served)
