### PR TITLE
Require lossless and alpha support for WebP

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -73,7 +73,7 @@
 
 	// test webp support, only when the markup calls for it
 	pf.types[ "image/webp" ] = function(){
-		// based on Modernizr's img-webp test
+		// based on Modernizr's lossless img-webp test
 		// note: asynchronous
 		var img = new w.Image(),
 			type = "image/webp";
@@ -86,7 +86,7 @@
 			pf.types[ type ] = img.width === 1;
 			picturefill();
 		};
-		img.src = 'data:image/webp;base64,UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/vuUAAA=';
+		img.src = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=';
 	};
 
 	/**


### PR DESCRIPTION
This is a fix for #211.

Testing for lossless WebP should help to avoid false positives when a browser does not support lossless or alpha WebP.

Only testing for "lossless" should be enough, because all browsers that support lossless should be able to render alpha too. ([browser support](https://developers.google.com/speed/webp/faq#which_web_browsers_natively_support_webp))

This means that picturefill will **not** use WebP images in older browsers that have only "lossy" Webp support:
- Google Chrome (desktop) 17-22
- Opera 11.xx, 12.00
- Native web browser, Android 4.0-4.1

Data URI is taken from Modernizr:
https://github.com/Modernizr/Modernizr/blob/master/feature-detects/img/webp-lossless.js
