### PR TITLE
Build: Bump JSHint and extract settings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,15 @@
+{
+	"curly": true,
+	"eqeqeq": true,
+	"immed": true,
+	"latedef": true,
+	"newcap": true,
+	"noarg": true,
+	"sub": true,
+	"undef": true,
+	"unused": true,
+	"boss": true,
+	"eqnull": true,
+	"node": true,
+	"predef": [ "define", "module" ]
+}

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -44,27 +44,15 @@
       jshint: {
         all: {
           options: {
-              "curly": true,
-              "eqeqeq": true,
-              "immed": true,
-              "latedef": true,
-              "newcap": true,
-              "noarg": true,
-              "sub": true,
-              "undef": true,
-              "unused": true,
-              "boss": true,
-              "eqnull": true,
-            "node": true,
-            "predef": [ "define", "module" ]
+            jshintrc: true
           },
-          src: [ 'Gruntfile.js', 'src/*.js' ]
+          src: [ 'Gruntfile.js', 'src/*.js', 'tests/*.js' ]
         }
       },
       watch: {
         gruntfile: {
-          files: [ 'Gruntfile.js', 'src/*.js'],
-          tasks: [ 'jshint', 'qunit', 'clean', 'concat', 'uglify' ]
+          files: [ 'Gruntfile.js', 'src/*.js', 'tests/*.js' ],
+          tasks: [ 'default' ]
         }
       }
     });
@@ -82,13 +70,13 @@
     // These plugins provide necessary tasks.
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-concat');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-qunit');
+    grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-watch');
 
     // Default task.
-    grunt.registerTask('default', ['jshint', 'qunit', 'clean', 'concat', 'uglify']);
+    grunt.registerTask('default', ['test', 'clean', 'concat', 'uglify']);
     grunt.registerTask('test', ['jshint', 'qunit']);
   };
 })();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"devDependencies": {
 		"grunt-cli": "~0.1",
-		"grunt-contrib-jshint": "~0.6.0",
+		"grunt-contrib-jshint": "~0.10.0",
 		"grunt-contrib-qunit": "~0.2.0",
 		"grunt-contrib-concat": "~0.3.0",
 		"grunt-contrib-uglify": "~0.2.0",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,0 +1,9 @@
+{
+	"sub": true,
+	"multistr": true,
+	"globals": {
+		"test": false,
+		"ok": false,
+		"deepEqual": false
+	}
+}

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -46,18 +46,19 @@
 	});
 
 	test("findWidthFromSourceSize", function() {
+		var width;
 		var sizes = "	 (max-width: 30em) 1000px,	 (max-width: 50em) 750px, 500px	 ";
 
 		pf.matchesMedia = function(media) {
 			return true;
 		};
-		var width = pf.findWidthFromSourceSize(sizes);
+		width = pf.findWidthFromSourceSize(sizes);
 		equal(width, 1000, "returns 1000 when match media returns true");
 
 		pf.matchesMedia = function(media) {
 			return false;
 		};
-		var width = pf.findWidthFromSourceSize(sizes);
+		width = pf.findWidthFromSourceSize(sizes);
 		equal(width, 500, "returns 500 when match media returns false");
 	});
 
@@ -85,6 +86,7 @@
 	});
 
 	test("getCandidatesFromSourceSet", function() {
+		var sizes;
 		// Basic test
 		var candidate1 = "images/pic-medium.png";
 		var expectedFormattedCandidates1 = [
@@ -132,7 +134,7 @@
 
 		// Test with multiple spaces
 		var candidate3 = "			images/pic-medium.png		 1x		,		 images/pic-medium-2x.png		 2x		";
-		deepEqual(pf.getCandidatesFromSourceSet(candidate3), expectedFormattedCandidates2, "Works!")
+		deepEqual(pf.getCandidatesFromSourceSet(candidate3), expectedFormattedCandidates2, "Works!");
 
 		// Test with decimals
 		var candidate4 = "			images/pic-smallest.png		 0.25x	 ,		images/pic-small.png		0.5x	 , images/pic-medium.png 1x";
@@ -154,13 +156,13 @@
 
 		// Test with "sizes" passed with a px length specified
 		var candidate5 = "			images/pic-smallest.png		 250w		,		 images/pic-small.png		 500w		, images/pic-medium.png 1000w";
-		var sizes = "1000px";
+		sizes = "1000px";
 		deepEqual(pf.getCandidatesFromSourceSet(candidate5, sizes), expectedFormattedCandidates4, "Works!");
 
 		// Test with "sizes" passed with % lengths specified
 		var candidate6 = "\npic320.png 320w	 , pic640.png		640w, pic768.png 768w, \
 		\npic1536.png 1536w, pic2048.png	2048w	 ";
-		var sizes = "	 (max-width: 30em) 100%,	 (max-width: 50em) 50%, 33%";
+		sizes = "	 (max-width: 30em) 100%,	 (max-width: 50em) 50%, 33%";
 		var expectedCandidates = [
 			{
 				resolution: 0.5,
@@ -186,7 +188,7 @@
 
 		pf.getWidthFromLength = function(width) {
 			return 640;
-		}
+		};
 
 		pf.matchesMedia = function(media) {
 			return true;


### PR DESCRIPTION
- Bump JSHint to latest release
- Use .jshintrc files so JSHint can also be run by IDEs
- JSHint test files
