### PR TITLE
Bower: Update missing fields

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,10 +2,32 @@
 	"name": "picturefill",
 	"repo": "scottjehl/picturefill",
 	"description": "A Polyfill for the HTML Picture Element (http://picture.responsiveimages.org/) that you can use today.",
-	"version": "2.0.0-beta",
-	"main": "picturefill.js",
+	"version": "2.0.0",
+	"main": "dist/picturefill.js",
 	"scripts": [
 		"dist/picturefill.js"
 	],
-	"licence": "MIT"
+	"licence": "MIT",
+	"homepage": "http://scottjehl.github.com/picturefill/",
+	"authors": [
+		"Scott Jehl <scottjehl@gmail.com>"
+	],
+	"moduleType": [
+		"amd",
+		"globals",
+		"node"
+	],
+	"keywords": [
+		"picture",
+		"srcset",
+		"polyfill"
+	],
+	"license": "MIT",
+	"ignore": [
+		"**/.*",
+		"node_modules",
+		"bower_components",
+		"test",
+		"tests"
+	]
 }


### PR DESCRIPTION
Re-ran bower init and filled in the missing fields. Was't sure what to do about the authors since the URL/file format isn't supported.
