### PR TITLE
Ignore examples/ directory in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,9 @@
 	"scripts": [
 		"dist/picturefill.js"
 	],
+	"ignore": [
+		"**/.*",
+		"examples/"
+  	],
 	"licence": "MIT"
 }


### PR DESCRIPTION
It's probably work excluding the examples/ directory in the bower config as it pulls down a lot of images when checking out.
