### PR TITLE
Correcting path of bower.json property "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
 	"repo": "scottjehl/picturefill",
 	"description": "A Polyfill for the HTML Picture Element (http://picture.responsiveimages.org/) that you can use today.",
 	"version": "2.0.0-beta",
-	"main": "picturefill.js",
+	"main": "dist/picturefill.js",
 	"scripts": [
 		"dist/picturefill.js"
 	],


### PR DESCRIPTION
The property `main` in bower.json is incorrect. It should be `dist/picturefill.js`.

This is necessary for some build tools. The specific build tool I was using when I found this was [wiredep](https://github.com/taptapship/wiredep).

In this case the browser was trying to load `bower_components/picturefill/picturefill.js` which does not exist.

Reference: [bower.json-spec#main](https://github.com/bower/bower.json-spec#main)
