### PR TITLE
return a picturefill as a noop if <picture> is implemented

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -9,6 +9,7 @@
 
 	// If picture is supported, well, that's awesome. Let's get outta here...
 	if ( w.HTMLPictureElement ) {
+		w.picturefill = function() { };
 		return;
 	}
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -2,6 +2,7 @@
 	if ( window.HTMLPictureElement ){
 		test( "Picture is natively supported", function() {
 			ok( window.HTMLPictureElement );
+			ok( window.picturefill );
 		});
 
 		return;


### PR DESCRIPTION
Any calls to `picturefill()` will throw an error as browsers implement HTMLPictureElement.
