### PR TITLE
Properly check for sizes support

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -23,8 +23,11 @@
 	pf.ns = "picturefill";
 
 	// srcset support test
-	pf.srcsetSupported = "srcset" in doc.createElement( "img" );
-	pf.sizesSupported = "sizes" in doc.createElement( "img" );
+	(function() {
+		var img = doc.createElement( "img" );
+		pf.srcsetSupported = "srcset" in img;
+		pf.sizesSupported = "sizes" in img;
+	})();
 
 	// just a string trim workaround
 	pf.trim = function( str ) {


### PR DESCRIPTION
`w.HTMLImageElement.sizes` is bogus -- there's no sizes property on the interface object. Per spec, it should be on the prototype, but that's not widely implemented yet (in some browsers it would go on the instance instead).
