### PR TITLE
+ jsDelvr CDN mention

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@ document.createElement( &quot;picture&quot; );
 </code></pre>
 
 		<p class="note">Note that if you are already including a recent version of the HTML5 Shiv (sometimes packaged with Modernizr), you may not need this line as it is included there as well. Also, more advanced users may not need this may choose to load Picturefill dynamically using a script loader like Require.js, (AMD and CommonJS support is included in the script).</p>
+		<p class="note">Latest versions are also hosted on the free CDN <a href="http://www.jsdelivr.com/#!picturefill">jsDelivr</a>.</p>
 
 
 		<h2 id="examples">Basic markup patterns</h2>


### PR DESCRIPTION
Added mention for jsDelivr free [CDN](http://www.jsdelivr.com/about.php).
Everytime you push a new [release](https://github.com/scottjehl/picturefill/releases), jsDelivr will be automatically updated.

At first I thought about adding a HTML code example, but figured adding a side-note under 'advanced' usage is keep with tone?
