### PR TITLE
fixed feature detection for sizes support

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -23,8 +23,9 @@
 	pf.ns = "picturefill";
 
 	// srcset support test
-	pf.srcsetSupported = "srcset" in doc.createElement( "img" );
-	pf.sizesSupported = w.HTMLImageElement.sizes;
+	var imgEl = doc.createElement( "img" );
+	pf.srcsetSupported = "srcset" in imgEl;
+	pf.sizesSupported = "sizes" in imgEl;
 
 	// just a string trim workaround
 	pf.trim = function( str ) {


### PR DESCRIPTION
Chrome Canary 39 (which supports srcset **with sizes**) reports the following:

```
"srcset" in document.createElement( "img" ); // true
HTMLImageElement.sizes; // undefined
"sizes" in document.createElement( "img" ); // true
```

Chrome 37 (which does support srcset **but not sizes**) reports:

```
"srcset" in document.createElement( "img" ); // true
HTMLImageElement.sizes; // undefined
"sizes" in document.createElement( "img" ); // false
```

I updated feature detection accordingly. (I appreciate that Chrome Canary 39 supports the picture tag so never reaches that code but other browsers may implement full srcset support without adding the picture tag)
