### PR TITLE
pf.parseDescriptor incorrectly loops starting from length + 1

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -263,17 +263,15 @@
 			if ( sizeDescriptor ) {
 				var splitDescriptor = sizeDescriptor.split(" ");
 
-				for (var i = splitDescriptor.length + 1; i >= 0; i--) {
-					if ( splitDescriptor[ i ] !== undefined ) {
-						var curr = splitDescriptor[ i ],
-							lastchar = curr && curr.slice( curr.length - 1 );
+				for (var i = splitDescriptor.length - 1; i >= 0; i--) {
+					var curr = splitDescriptor[ i ],
+						lastchar = curr && curr.slice( curr.length - 1 );
 
-						if ( ( lastchar === "h" || lastchar === "w" ) && !pf.sizesSupported ) {
-							resCandidate = parseFloat( ( parseInt( curr, 10 ) / widthInCssPixels ) );
-						} else if ( lastchar === "x" ) {
-							var res = curr && parseFloat( curr, 10 );
-							resCandidate = res && !isNaN( res ) ? res : 1;
-						}
+					if ( ( lastchar === "h" || lastchar === "w" ) && !pf.sizesSupported ) {
+						resCandidate = parseFloat( ( parseInt( curr, 10 ) / widthInCssPixels ) );
+					} else if ( lastchar === "x" ) {
+						var res = curr && parseFloat( curr, 10 );
+						resCandidate = res && !isNaN( res ) ? res : 1;
 					}
 				}
 			}


### PR DESCRIPTION
Not necessary a bug that causes any problem, but it did look odd when I was debugging through the code.

fixed incorrect looping from length + 1 to length in parse descriptor
and removed unnecessary undefined check
