### PR TITLE
changed this to window in the IIFE's parameter list.

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -197,8 +197,8 @@
 		 *
 		 * 1. Let input (`srcset`) be the value passed to this algorithm.
 		 * 2. Let position be a pointer into input, initially pointing at the start of the string.
-		 * 3. Let raw candidates be an initially empty ordered list of URLs with associated 
-		 *    unparsed descriptors. The order of entries in the list is the order in which entries 
+		 * 3. Let raw candidates be an initially empty ordered list of URLs with associated
+		 *    unparsed descriptors. The order of entries in the list is the order in which entries
 		 *    are added to the list.
 		 */
 		var candidates = [];
@@ -225,7 +225,7 @@
 				}
 				srcset = srcset.slice( pos + 1 );
 
-				// 6.2. Collect a sequence of characters that are not U+002C COMMA characters (,), and 
+				// 6.2. Collect a sequence of characters that are not U+002C COMMA characters (,), and
 				// let that be descriptors.
 				if ( descriptor === null ) {
 					var descpos = srcset.indexOf( "," );
@@ -254,7 +254,7 @@
 	};
 
 	pf.parseDescriptor = function( descriptor, sizesattr ) {
-		// 11. Descriptor parser: Let candidates be an initially empty source set. The order of entries in the list 
+		// 11. Descriptor parser: Let candidates be an initially empty source set. The order of entries in the list
 		// is the order in which entries are added to the list.
 		var sizes = sizesattr || "100vw",
 			sizeDescriptor = descriptor && descriptor.replace( /(^\s+|\s+$)/g, "" ),
@@ -607,4 +607,4 @@
 		w.picturefill = picturefill;
 	}
 
-} )( this, this.document, new this.Image() );
+} )( window, window.document, new window.Image() );


### PR DESCRIPTION
I think it's not a good idea to use "this" as the window object. 

We use Picturefill as a browserify module (Common JS syntax) which means we include it within an outer scope that is already under strict mode. 

In strict mode, "this" doesn't refer to the window object and the second argument of the IIFE (which would be the document) is undefined in our case.

It causes a JS error in the 17th line. (There is no method called createElement of undefined.)
