### PR TITLE
Fix common js installation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "picturefill",
 	"description": "A responsive image polyfill.",
 	"version": "2.2.0",
-	"repo": "https://github.com/scottjehl/picturefill.git",
+	"repository": "https://github.com/scottjehl/picturefill.git",
 	"engines": {
 		"node": ">= 0.8.0"
 	},


### PR DESCRIPTION
Fixes npm installation warnings due to wrong named field in package.json

``` bash
npm WARN package.json picturefill@2.2.0 No repository field.
npm WARN package.json picturefill@2.2.0 repo should probably be repository.
```

Reference https://www.npmjs.org/doc/files/package.json.html#repository
