### PR TITLE
Updating the version number for bower - Fixes 338

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
 	"name": "picturefill",
 	"repo": "scottjehl/picturefill",
 	"description": "A Polyfill for the HTML Picture Element (http://picture.responsiveimages.org/) that you can use today.",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"main": "dist/picturefill.js",
 	"scripts": [
 		"dist/picturefill.js"


### PR DESCRIPTION
This would mark the current version as 2.2.0 for bower. Once this is merged in, it will have to be published to the bower repository. Fixes part of #338 based on @seleckis' last comment.
