### PR TITLE
Updating package.json to include more metadata which is better for npmjs.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
 	"homepage": "https://scottjehl.github.io/picturefill/",
 	"bugs": "https://github.com/scottjehl/picturefill/issues",
 	"license": "MIT",
+	"author": "Scott Jehl <scottjehl@gmail.com>",
+	"repository": {
+		"type": "git",
+		"url": "git@github.com:scottjehl/picturefill.git"
+	},
 	"keywords": [
 		"picturefill",
 		"srcset",


### PR DESCRIPTION
There was a discussion a while back on how to get more visibility on npmjs.org. I've added some more metadata to help in searches, find the demo page. Not all of this is necessary but none of it hurts!
