### PR TITLE
Fix Readme styling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # Picturefill
+# Picturefill
 A [responsive image](http://www.whatwg.org/specs/web-apps/current-work/multipage/embedded-content.html#embedded-content) polyfill.
 * Authors: Scott Jehl, Mat Marquis, Shawn Jansepar (2.0 refactor lead), and many more: see Authors.txt
 * License: MIT


### PR DESCRIPTION
A space in front of the # prevents it from becoming a header in Markdown.
