### PR TITLE
simplify API for reparsing srcset and src attributes on image elements

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -1272,13 +1272,13 @@
 		return match;
 	};
 
-	ri.parseSets = function( element, parent ) {
+	ri.parseSets = function( element, parent, options ) {
 		var srcsetAttribute, imageSet, isWDescripor, srcsetParsed;
 
 		var hasPicture = parent.nodeName.toUpperCase() === "PICTURE";
 		var imageData = element[ ri.ns ];
 
-		if ( imageData.src === undefined ) {
+		if ( imageData.src === undefined || options.src ) {
 			imageData.src = getImgAttr.call( element, "src" );
 			if ( imageData.src ) {
 				setImgAttr.call( element, srcAttr, imageData.src );
@@ -1287,7 +1287,7 @@
 			}
 		}
 
-		if ( imageData.srcset === undefined ) {
+		if ( imageData.srcset === undefined || options.srcset || !ri.supSrcset || element.srcset ) {
 			srcsetAttribute = getImgAttr.call( element, "srcset" );
 			imageData.srcset = srcsetAttribute;
 			srcsetParsed = true;
@@ -1332,6 +1332,7 @@
 		}
 
 		imageData.curCan = null;
+		imageData.curSrc = undefined;
 
 		// if img has picture or the srcset was removed or has a srcset and does not support srcset at all
 		// or has a w descriptor (and does not support sizes) set support to false to evaluate

--- a/src/plugins/mutation/pf.mutation.js
+++ b/src/plugins/mutation/pf.mutation.js
@@ -211,19 +211,16 @@
 
 		if ( !riData &&
 			mutation.attributeName === "srcset" &&
-			mutation.target.nodeName.toUpperCase() === "IMG" ) {
+			(nodeName = mutation.target.nodeName.toUpperCase()) === "IMG" ) {
 			ri.addToElements( mutation.target, modifiedImgs );
 		} else if ( riData ) {
-			nodeName = mutation.target.nodeName.toUpperCase();
+			if(!nodeName){
+				nodeName = mutation.target.nodeName.toUpperCase();
+			}
 
 			if ( nodeName === "IMG" ) {
 				if ( mutation.attributeName in riData ) {
 					riData[ mutation.attributeName ] = undefined;
-
-					if ( mutation.attributeName === "src" || ( ri.supSrcset && mutation.attributeName === "srcset" ) ) {
-						riData.curCan = null;
-						riData.curSrc = undefined;
-					}
 				}
 				ri.addToElements( mutation.target, modifiedImgs );
 			} else if ( nodeName === "SOURCE" ) {


### PR DESCRIPTION
This change simplifys the API for reparsing elements, if no mutation plugin is in use. 