### PR TITLE
fix 100vw fallback, if all provided sizes are invalid/unknown to the browser

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -88,8 +88,10 @@
 	 */
 	pf.getWidthFromLength = function( length ) {
 		var cssValue;
-		// If a length is specified and doesn’t contain a percentage, and it is greater than 0 or using `calc`, use it. Else, use the `100vw` default.
-		length = length && length.indexOf( "%" ) > -1 === false && ( parseFloat( length ) > 0 || length.indexOf( "calc(" ) > -1 ) ? length : "100vw";
+		// If a length is specified and doesn’t contain a percentage, and it is greater than 0 or using `calc`, use it. Else, abort.
+        if ( !(length && length.indexOf( "%" ) > -1 === false && ( parseFloat( length ) > 0 || length.indexOf( "calc(" ) > -1 )) ) {
+            return false;
+        }
 
 		/**
 		 * If length is specified in  `vw` units, use `%` instead since the div we’re measuring
@@ -210,7 +212,7 @@
 		}
 
 		//if we have no winningLength fallback to 100vw
-		return winningLength || Math.max(w.innerWidth || 0, doc.document.clientWidth);
+		return winningLength || Math.max(w.innerWidth || 0, doc.documentElement.clientWidth);
 	};
 
 	pf.parseSrcset = function( srcset ) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -68,6 +68,11 @@
 		sizes = "100foo, 200px";
 		width = pf.findWidthFromSourceSize(sizes);
 		equal(width, 200, "returns 200 when there was an unknown css length");
+
+        sizes = "100foo, sd2300bar";
+        width = pf.findWidthFromSourceSize(sizes);
+
+        equal(width, Math.max(window.innerWidth || 0, document.documentElement.clientWidth), "returns 100vw when all sizes are an unknown css length");
 	});
 
 	asyncTest("setIntrinsicSize", function() {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -69,10 +69,10 @@
 		width = pf.findWidthFromSourceSize(sizes);
 		equal(width, 200, "returns 200 when there was an unknown css length");
 
-        sizes = "100foo, sd2300bar";
-        width = pf.findWidthFromSourceSize(sizes);
+		sizes = "100foo, sd2300bar";
+		width = pf.findWidthFromSourceSize(sizes);
 
-        equal(width, Math.max(window.innerWidth || 0, document.documentElement.clientWidth), "returns 100vw when all sizes are an unknown css length");
+		equal(width, Math.max(window.innerWidth || 0, document.documentElement.clientWidth), "returns 100vw when all sizes are an unknown css length");
 	});
 
 	asyncTest("setIntrinsicSize", function() {


### PR DESCRIPTION
While working on #461, I realized, that our parseSizes algo fix wasn't 100% complete. This fixes it and also adds a test to ensure it. As you know, 'm eager to see a final release of 2.3 so. Please review quickly ;-). ping: @baloneysandwiches , @wilto, @scottjehl.