### PR TITLE
Fix #464 - Added support for logical operators in media queries

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -170,8 +170,9 @@
 	};
 
 	// Parses an individual `size` and returns the length, and optional media query
+	// Logical operators for media query are supported
 	pf.parseSize = function( sourceSizeStr ) {
-		var match = /(\([^)]+\))?\s*(.+)/g.exec( sourceSizeStr );
+		var match = /((?:\([^)]+\)(?:\s*and\s*|\s*or\s*)?)+)?\s*(.+)/g.exec( sourceSizeStr );
 		return {
 			media: match && match[1],
 			length: match && match[2]

--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -172,7 +172,7 @@
 	// Parses an individual `size` and returns the length, and optional media query
 	// Logical operators for media query are supported
 	pf.parseSize = function( sourceSizeStr ) {
-		var match = /((?:\([^)]+\)(?:\s*and\s*|\s*or\s*)?)+)?\s*(.+)/g.exec( sourceSizeStr );
+		var match = /((?:\s*(?:\([^)]+\)+|(?!calc)[a-zA-Z]))+)?\s*(.+)/gi.exec( sourceSizeStr );
 		return {
 			media: match && match[1],
 			length: match && match[2]

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -127,6 +127,14 @@
 			media: "(min-width:30em)"
 		};
 		deepEqual(pf.parseSize(size3), expected3, "Length and Media are properly parsed");
+
+		var size4 = "(min-width: 30em) and (max-width: 50em) 50%";
+		var expected4 = {
+			length: "50%",
+			media: "(min-width: 30em) and (max-width: 50em)"
+		};
+		deepEqual(pf.parseSize(size4), expected4, "Length and Media are properly parsed");
+
 	});
 
 	test("getCandidatesFromSourceSet", function() {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -128,12 +128,33 @@
 		};
 		deepEqual(pf.parseSize(size3), expected3, "Length and Media are properly parsed");
 
-		var size4 = "(min-width: 30em) and (max-width: 50em) 50%";
+		var size4 = "only screen and (((min-width: 30em) and (max-width: 50em)) or (min-width: 150em)) 50%";
 		var expected4 = {
 			length: "50%",
-			media: "(min-width: 30em) and (max-width: 50em)"
+			media: "only screen and (((min-width: 30em) and (max-width: 50em)) or (min-width: 150em))"
 		};
 		deepEqual(pf.parseSize(size4), expected4, "Length and Media are properly parsed");
+
+		var size5 = "not print 50%";
+		var expected5 = {
+			length: "50%",
+			media: "not print"
+		};
+		deepEqual(pf.parseSize(size5), expected5, "Length and Media are properly parsed");
+		
+		var size6 = "(min-width: 50.01em) and all 50%";
+		var expected6 = {
+			length: "50%",
+			media: "(min-width: 50.01em) and all"
+		};
+		deepEqual(pf.parseSize(size6), expected6, "Length and Media are properly parsed");
+		
+		var size7 = "50%";
+		var expected7 = {
+			length: "50%",
+			media: undefined
+		};
+		deepEqual(pf.parseSize(size7), expected7, "Length and Media are properly parsed");
 
 	});
 


### PR DESCRIPTION
Changed regex to capture multiple queries connected with "and" or "or" logical operators.

* Automated tests passed
* Handmade tests passed
* Candidate regex performance checked: http://jsperf.com/picturefill-regex-candidate