### PR TITLE
Remove "repo" line from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "picturefill",
 	"description": "A responsive image polyfill.",
 	"version": "2.3.0",
-	"repo": "https://github.com/scottjehl/picturefill.git",
 	"homepage": "https://scottjehl.github.io/picturefill/",
 	"bugs": "https://github.com/scottjehl/picturefill/issues",
 	"license": "MIT",


### PR DESCRIPTION
This PR removes the warning
`npm WARN package.json picturefill@2.3.0 repo should probably be repository.`
that is thrown when `npm install`is exectued.

`"repository"` is defined [as it should be](https://docs.npmjs.com/files/package.json#repository) so the data removed in this PR is not necessary.