### PR TITLE
Fix for #464

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -181,7 +181,7 @@
 
 	// Parses an individual `size` and returns the length, and optional media query
 	pf.parseSize = function( sourceSizeStr ) {
-		var match = /(\([^)]+\))?\s*(.+)/g.exec( sourceSizeStr );
+		var match = /((?:\([^()]+\)(?:\s*(?:and|or|not)\s*)?)+)?\s*(.+)/g.exec( sourceSizeStr );
 		return {
 			media: match && match[1],
 			length: match && match[2]

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -131,6 +131,20 @@
 			media: "(min-width:30em)"
 		};
 		deepEqual(pf.parseSize(size3), expected3, "Length and Media are properly parsed");
+		
+		var size4 = "(min-width: 30em) and (max-width: 50em) or (min-width: 150em) not (min-resolution: 144dpi) 50%";
+		var expected4 = {
+			length: "50%",
+			media: "(min-width: 30em) and (max-width: 50em) or (min-width: 150em) not (min-resolution: 144dpi)"
+		};
+		deepEqual(pf.parseSize(size4), expected4, "Length and Media are properly parsed");
+
+		var size5 = "50%";
+		var expected5 = {
+			length: "50%",
+			media: undefined
+		};
+		deepEqual(pf.parseSize(size5), expected5, "Length and Media are properly parsed");
 	});
 
 	test("getCandidatesFromSourceSet", function() {


### PR DESCRIPTION
Amended as asked by @aFarkas in https://github.com/scottjehl/picturefill/pull/463

Performance tests for this revision show no performance cost:
http://jsperf.com/picturefill-regex-candidate/13
http://jsperf.com/picturefill-regex-candidate-performance-simple/2

Should work like a charm :)