### PR TITLE
update checkResize to not redefine resizeThrottle

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -658,9 +658,8 @@
 			}
 		}, 250 );
 
+		var resizeThrottle;
 		function checkResize() {
-			var resizeThrottle;
-
 			if ( !w._picturefillWorking ) {
 				w._picturefillWorking = true;
 				w.clearTimeout( resizeThrottle );


### PR DESCRIPTION
Otherwise its calling clearTimeout on undefined and the delayed function is still fired