### PR TITLE
add currentSrc support detection (fixes #478)

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -43,6 +43,7 @@
 	(function() {
 		pf.srcsetSupported = "srcset" in image;
 		pf.sizesSupported = "sizes" in image;
+		pf.curSrcSupported = "currentSrc" in image;
 	})();
 
 	// just a string trim workaround
@@ -455,7 +456,9 @@
 					picImg.src = bestCandidate.url;
 					// currentSrc attribute and property to match
 					// http://picture.responsiveimages.org/#the-img-element
-					picImg.currentSrc = picImg.src;
+					if ( !pf.curSrcSupported ) {
+						picImg.currentSrc = picImg.src;
+					}
 
 					pf.backfaceVisibilityFix( picImg );
 				}


### PR DESCRIPTION
While I think we can simply just remove ``currentSrc`` polyfill (Because it is broken and has no value), we can maintain backwards compatibility by simply doing an additional support check.