### PR TITLE
Grunt automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ node_modules
 **/.sass-cache/*
 *.bak
 *.zip
+.grunt
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -19,7 +19,7 @@
         files: [ "dist" ]
       },
       concat: {
-        
+
         dist: {
           options: {
             banner: "<%= banner %>",
@@ -38,7 +38,7 @@
           dest: "dist/picturefill.min.js"
         }
       },
-      
+
       qunit: {
         files: [ "tests/**/*.html" ]
       },
@@ -53,6 +53,20 @@
       jscs: {
         all: {
           src: "<%= jshint.all.src %>"
+        }
+      },
+      "gh-pages": {
+        options: {
+          base: '.'
+        },
+        src: ["**/*", "!node_modules/**/*", "!test/**/*", "!src/**/*"]
+      },
+      release: {
+        options: {
+          additionalFiles: ["bower.json"],
+          commitMessage: "Picturefill <%= version %>",
+          tagMessage: "Picturefill <%= version %>",
+          afterRelease: ["gh-pages"]
         }
       },
       watch: {
@@ -84,26 +98,27 @@
     grunt.loadNpmTasks("grunt-contrib-uglify");
     grunt.loadNpmTasks("grunt-contrib-watch");
     grunt.loadNpmTasks("grunt-jscs-checker");
-    
+    grunt.loadNpmTasks("grunt-gh-pages");
+
     grunt.task.registerTask("support-types", "insert support for image types dev wants to include", function() {
       var supportTypes = "";
       for (var i = 0; i < arguments.length; i++) {
         var arg = arguments[i];
-        
+
         switch ( arg ) {
-          case "webp": 
+          case "webp":
           case "svg":
           case "jxr":
           case "jp2":
           case "apng":
-          
+
             toConcat.push("src/includes/" + arg + ".js");
         }
-        
+
         supportTypes += ":" + arg;
-        
+
       }
-      
+
       if (!supportTypes) {
         supportTypes = supportTypes;
       }
@@ -114,5 +129,6 @@
 	// Default task.
     grunt.registerTask("default", [ "jscs", "test", "clean", "concat", "uglify" ]);
     grunt.registerTask("test", [ "jscs", "jshint", "qunit" ]);
+    grunt.registerTask("publish", [ "gh-pages" ]);
   };
 })();

--- a/package.json
+++ b/package.json
@@ -1,39 +1,40 @@
 {
-	"name": "picturefill",
-	"description": "A responsive image polyfill.",
-	"version": "2.3.0",
-	"homepage": "https://scottjehl.github.io/picturefill/",
-	"bugs": "https://github.com/scottjehl/picturefill/issues",
-	"license": "MIT",
-	"author": "Scott Jehl <scottjehl@gmail.com>",
-	"repository": {
-		"type": "git",
-		"url": "git@github.com:scottjehl/picturefill.git"
-	},
-	"keywords": [
-		"picturefill",
-		"srcset",
-		"picture",
-		"responsive",
-		"responsive images"
-	],
-	"engines": {
-		"node": ">= 0.8.0"
-	},
-	"main": "./dist/picturefill",
-	"scripts": {
-		"test": "grunt test --verbose"
-	},
-	"devDependencies": {
-		"grunt": "~0.4.2",
-		"grunt-cli": "~0.1",
-		"grunt-contrib-clean": "~0.4.0",
-		"grunt-contrib-concat": "~0.3.0",
-		"grunt-contrib-jshint": "~0.10.0",
-		"grunt-contrib-qunit": "~0.2.0",
-		"grunt-contrib-uglify": "~0.2.0",
-		"grunt-contrib-watch": "~0.6.0",
-		"grunt-jscs-checker": "~0.4.3",
-		"grunt-insert": "~0.1.0"
-	}
+  "name": "picturefill",
+  "description": "A responsive image polyfill.",
+  "version": "2.3.0",
+  "homepage": "https://scottjehl.github.io/picturefill/",
+  "bugs": "https://github.com/scottjehl/picturefill/issues",
+  "license": "MIT",
+  "author": "Scott Jehl <scottjehl@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:scottjehl/picturefill.git"
+  },
+  "keywords": [
+    "picturefill",
+    "srcset",
+    "picture",
+    "responsive",
+    "responsive images"
+  ],
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "main": "./dist/picturefill",
+  "scripts": {
+    "test": "grunt test --verbose"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.2",
+    "grunt-cli": "~0.1",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-qunit": "~0.2.0",
+    "grunt-contrib-uglify": "~0.2.0",
+    "grunt-contrib-watch": "~0.6.0",
+    "grunt-gh-pages": "^0.10.0",
+    "grunt-insert": "~0.1.0",
+    "grunt-jscs-checker": "~0.4.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "grunt-contrib-watch": "~0.6.0",
     "grunt-gh-pages": "^0.10.0",
     "grunt-insert": "~0.1.0",
-    "grunt-jscs-checker": "~0.4.3"
+    "grunt-jscs-checker": "~0.4.3",
+    "grunt-release": "^0.12.0"
   }
 }


### PR DESCRIPTION
Changes include:

- a gh-pages task to publish changes to gh-pages
- a publish task to run gh-pages (and any others in the future)
- a release task, which will bump the version number in package.json and bower.json, create a git tag, push the changes up, publish to npm, then run the gh-pages task. More info here: https://www.npmjs.com/package/grunt-release. And an example:

`grunt release:2.3.0`

paging @wilto and anyone else who wants a look-see.