### PR TITLE
Fixing Regex to work with multiple Media Query rules

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -182,10 +182,10 @@
 
 	// Parses an individual `size` and returns the length, and optional media query
 	pf.parseSize = function( sourceSizeStr ) {
-		var match = /(\([^)]+\))?\s*(.+)/g.exec( sourceSizeStr );
+		var match = /(\([^)]+\)([^0-9]+[^)]+\))*)?\s*(.+)/g.exec( sourceSizeStr );
 		return {
 			media: match && match[1],
-			length: match && match[2]
+			length: match && match[3]
 		};
 	};
 


### PR DESCRIPTION
Fixing Regex to work with multiple Media Query rules, like: "(min-height: 900px) and (min-width: 992px) 150px"
![2015-04-16_1845](https://cloud.githubusercontent.com/assets/1202698/7187510/d7e576d4-e468-11e4-9fb0-31e42fc81da0.png)
![2015-04-16_1845_001](https://cloud.githubusercontent.com/assets/1202698/7187508/d7e41730-e468-11e4-957c-0e4a7c7cfcde.png)
![2015-04-16_1843](https://cloud.githubusercontent.com/assets/1202698/7187509/d7e43116-e468-11e4-9a2f-2724a6be0bb6.png)


