### PR TITLE
Use browser field in package.json instead of main field

### DIFF
--- a/empty.js
+++ b/empty.js
@@ -1,0 +1,1 @@
+// placeholder file for nodejs

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "main": "./dist/picturefill",
+  "main": "empty.js",
+  "browser": "./dist/picturefill",
   "scripts": {
     "test": "grunt test --verbose"
   },


### PR DESCRIPTION
We've been using picturefill for like 4months, we are absolutely satisfied with it but as we are moving our React rendering to the backend we realized picturefill breaks in nodejs. Since it uses [`main` field](https://docs.npmjs.com/files/package.json#main) in `package.json` node tries to load the `dist/picturefill.js` which contains `window.matchMedia` and `window` in node is undefined.

Solutions:
1. Wrap polyfill in if where we are checking for the existance of `window`
   
   ```
   if (typeof window !== 'undefined') {
    ...polyfill code...
   }
   ```
   
   Imho it looks ugly:(
2. Use [`matchmedia`](https://github.com/iceddev/matchmedia) npm module which works on backend and client side as well (we should add a build step to picturefill)
3. Use `browser` field instead of main `field`

I would go with the 3rd one. Here why:
`polyfill` shouldn't work on backend since it uses `matchMedia` and picturefill shouldn't support node, but it does not mean it should break.
Browser field is a de facto way of separating client side module from backend, here's the spec: https://gist.github.com/defunctzombie/4339901

Also the 3rd way wont break any use cases:
- if you are using plain old `<script>` tag, you would still download the dist package
- if you are using browserify, it does support `browser` field: https://github.com/substack/node-browserify#browser-field
- if you are using webpack, it does support `browser` field: http://webpack.github.io/docs/configuration.html#resolve-packagemains

I moved `dist/picturefill.js` to browser field and changed the main field `empty.js`, which just an empty js file.
