### PR TITLE
improve saveData with cached images

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -11,7 +11,7 @@
 	// HTML shim|v it for old IE (IE9 will still need the HTML video tag workaround)
 	document.createElement( "picture" );
 
-	var warn, eminpx, alwaysCheckWDescriptor, evalId;
+	var warn, eminpx, alwaysCheckWDescriptor, evalId, maxCachedDPR, goodCachedDPR;
 	// local object for method references and testing exposure
 	var pf = {};
 	var noop = function() {};
@@ -274,6 +274,14 @@
 
 		units.em = pf.getEmValue();
 		units.rem = units.em;
+
+		if (cfg.algorithm === "saveData") {
+			goodCachedDPR = 0.6 + (0.5 * pf.DPR);
+			maxCachedDPR = pf.DPR + 1 + (0.5 * pf.DPR);
+		} else {
+			goodCachedDPR = pf.DPR;
+			maxCachedDPR = pf.DPR + 99;
+		}
 	}
 
 	function chooseLowRes( lowerValue, higherValue, dprValue, isCached ) {
@@ -1113,7 +1121,7 @@
 
 				// if current candidate is "best", "better" or "okay",
 				// set it to bestCandidate
-				if ( curCan && isSameSet && curCan.res >= dpr ) {
+				if ( curCan && isSameSet && curCan.res >= goodCachedDPR && curCan.res < maxCachedDPR ) {
 					bestCandidate = curCan;
 				}
 			}


### PR DESCRIPTION
I have some small improvements regarding to our saveData algorithm with cached images.

There are two improvements:

a) There are some sites using a lot of images (80+) often in conjunction with lazyloading. If most images are loaded and an orientation change happens the selection algorithm restarts. The change checks, wether the currently cached image is good enough and aborts the selection algorithm in that case.

b) Now, Chrome also fully supports `sizes` attribute mutations. I expect in the future, that devs developing a lightbox similar widget more often simply will change the `sizes` attribute to show a bigger image and then switch back to the original much smaller size. If the image size is much much larger for example 5x instead of 2x, it makes sense to not use this 5x image and to re-run the source selection.

I don't want to delay our release cycle with this PR. In case this would delay our RC and final releases, then don't take it.