### PR TITLE
Remove wrapper function in srcset check

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -40,11 +40,9 @@
 	pf.ns = "picturefill";
 
 	// srcset support test
-	(function() {
-		pf.srcsetSupported = "srcset" in image;
-		pf.sizesSupported = "sizes" in image;
-		pf.curSrcSupported = "currentSrc" in image;
-	})();
+	pf.srcsetSupported = "srcset" in image;
+	pf.sizesSupported = "sizes" in image;
+	pf.curSrcSupported = "currentSrc" in image;
 
 	// just a string trim workaround
 	pf.trim = function( str ) {


### PR DESCRIPTION
There are no variables declared here so it seems pointless to have a function.