### PR TITLE
extend sizes feature detect for Safari 9

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -917,6 +917,8 @@
 					pf.supSizes = true;
 				}
 
+				alwaysCheckWDescriptor = pf.supSrcset && !pf.supSizes;
+
 				isSupportTestReady = true;
 				// force async
 				setTimeout(picturefill);
@@ -948,8 +950,6 @@
 
 	// container of supported mime types that one might need to qualify before using
 	pf.types =  types;
-
-	alwaysCheckWDescriptor = pf.supSrcset && !pf.supSizes;
 
 	pf.setSize = noop;
 

--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -14,6 +14,7 @@
 	var warn, eminpx, alwaysCheckWDescriptor, evalId;
 	// local object for method references and testing exposure
 	var pf = {};
+	var isSupportTestReady = false;
 	var noop = function() {};
 	var image = document.createElement( "img" );
 	var getImgAttr = image.getAttribute;
@@ -183,6 +184,9 @@
 	 * @param opt
 	 */
 	var picturefill = function( opt ) {
+
+		if (!isSupportTestReady) {return;}
+
 		var elements, i, plen;
 
 		var options = opt || {};
@@ -888,6 +892,8 @@
 	pf.supSizes = "sizes" in image;
 	pf.supPicture = !!window.HTMLPictureElement;
 
+	// UC browser does claim to support srcset and picture, but not sizes,
+	// this extended test reveals the browser does support nothing
 	if (pf.supSrcset && pf.supPicture && !pf.supSizes) {
 		(function(image2) {
 			image.srcset = "data:,a";
@@ -897,15 +903,42 @@
 		})(document.createElement("img"));
 	}
 
+	// Safari9 has basic support for sizes, but does't expose the `sizes` idl attribute
+	if (pf.supSrcset && !pf.supSizes) {
+
+		(function() {
+			var width2 = "data:image/gif;base64,R0lGODlhAgABAPAAAP///wAAACH5BAAAAAAALAAAAAACAAEAAAICBAoAOw==";
+			var width1 = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+			var img = document.createElement("img");
+			var test = function() {
+				var width = img.width;
+
+				if (width === 2) {
+					pf.supSizes = true;
+				}
+
+				isSupportTestReady = true;
+				// force async
+				setTimeout(picturefill);
+			};
+
+			img.onload = test;
+			img.onerror = test;
+			img.setAttribute("sizes", "9px");
+
+			img.srcset = width1 + " 1w," + width2 + " 9w";
+			img.src = width1;
+		})();
+
+	} else {
+		isSupportTestReady = true;
+	}
+
 	// using pf.qsa instead of dom traversing does scale much better,
 	// especially on sites mixing responsive and non-responsive images
 	pf.selShort = "picture>img,img[srcset]";
 	pf.sel = pf.selShort;
 	pf.cfg = cfg;
-
-	if ( pf.supSrcset ) {
-		pf.sel += ",img[" + srcsetAttr + "]";
-	}
 
 	/**
 	 * Shortcut property for `devicePixelRatio` ( for easy overriding in tests )
@@ -1270,7 +1303,7 @@
 
 		// if img has picture or the srcset was removed or has a srcset and does not support srcset at all
 		// or has a w descriptor (and does not support sizes) set support to false to evaluate
-		imageData.supported = !( hasPicture || ( imageSet && !pf.supSrcset ) || isWDescripor );
+		imageData.supported = !( hasPicture || ( imageSet && !pf.supSrcset ) || (isWDescripor && !pf.supSizes) );
 
 		if ( srcsetParsed && pf.supSrcset && !imageData.supported ) {
 			if ( srcsetAttribute ) {

--- a/tests/tests-functional.js
+++ b/tests/tests-functional.js
@@ -117,7 +117,7 @@
 					setTimeout(picturefill);
 				}
 				afterImgLoad(run);
-			}, 33);
+			}, 120);
 			return results;
 		};
 

--- a/tests/tests-functional.js
+++ b/tests/tests-functional.js
@@ -283,7 +283,7 @@
 			});
 		});
 
-		if(!window.HTMLPictureElement){
+		if(!window.HTMLPictureElement && !ri.supSizes){
 			(function(){
 				var test = function(attrType) {
 					return function(){
@@ -478,53 +478,55 @@
 
 		if(ri.mutationSupport && (roundedDPR == 1 || roundedDPR == 2)){
 			(function(){
-				asyncTest('change attributes on img[srcset][sizes]', function(){
-					var $wimage = f$('<img src="'+ relurls['350x150'] +'" ' +
-						'srcset="' + relurls['2100x900'] +' 2100w 900h,'+ absurls['2800x1200'] + ' 1200h 2800w, '+ relurls['1400x600'] + ' 1400w, ' +relurls['350x150'] +' 350w,'+ relurls['700x300'] +' 700w" ' +
-						' sizes="345px" />');
+				if(!ri.supSizes){
+					asyncTest('change attributes on img[srcset][sizes]', function(){
+						var $wimage = f$('<img src="'+ relurls['350x150'] +'" ' +
+							'srcset="' + relurls['2100x900'] +' 2100w 900h,'+ absurls['2800x1200'] + ' 1200h 2800w, '+ relurls['1400x600'] + ' 1400w, ' +relurls['350x150'] +' 350w,'+ relurls['700x300'] +' 700w" ' +
+							' sizes="345px" />');
 
 
-					runMutationTests($wimage, [
-						{
-							expects: {
-								currentSrc: roundedDPR == 2 ? absurls['700x300'] : absurls['350x150']
-							}
-						},
-						{
-							attrs: {
-								'sizes': 'calc(344px + 344px)'
+						runMutationTests($wimage, [
+							{
+								expects: {
+									currentSrc: roundedDPR == 2 ? absurls['700x300'] : absurls['350x150']
+								}
 							},
-							expects: {
-								currentSrc: roundedDPR == 2 ? absurls['1400x600'] : absurls['700x300']
-							}
-						},
-						{
-							attrs: {
-								srcset: absurls['2800x1200']
+							{
+								attrs: {
+									'sizes': 'calc(344px + 344px)'
+								},
+								expects: {
+									currentSrc: roundedDPR == 2 ? absurls['1400x600'] : absurls['700x300']
+								}
 							},
-							expects: {
-								currentSrc: absurls['2800x1200']
-							}
-						},
-						{
-							attrs: {
-								srcset: null
+							{
+								attrs: {
+									srcset: absurls['2800x1200']
+								},
+								expects: {
+									currentSrc: absurls['2800x1200']
+								}
 							},
-							expects: {
-								currentSrc: absurls['350x150'],
-								srcProp: absurls['350x150']
-							}
-						},
-						{
-							attrs: {
-								src: null
+							{
+								attrs: {
+									srcset: null
+								},
+								expects: {
+									currentSrc: absurls['350x150'],
+									srcProp: absurls['350x150']
+								}
 							},
-							expects: {
-								currentSrc: ''
+							{
+								attrs: {
+									src: null
+								},
+								expects: {
+									currentSrc: ''
+								}
 							}
-						}
-					]);
-				});
+						]);
+					});
+				}
 
 				asyncTest('change attributes on img[src]', function(){
 					var $wimage = f$('<img src="'+ relurls['350x150'] +'" />');

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -747,10 +747,14 @@
 		});
 
 		asyncTest( "`img` can be added outside the DOM without errors", function() {
-			var runTest, timer;
+			var timer;
 			var img = document.createElement( "img" );
 			var runTest = function(){
-				equal( img.currentSrc || img.src, "data:img" );
+				if ('currentSrc' in img || !op.supSizes){
+					equal( img.currentSrc || img.src, "data:img" );
+				} else {
+					equal( img.srcset, "data:img 500w" );
+				}
 				start();
 				img.onload = null;
 				img.onerror = null;


### PR DESCRIPTION
This is clearly not ready for merge yet. I need to do some more testing, but want to have some early eyes on the changes.