### PR TITLE
Feature detect document.querySelector

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -939,6 +939,9 @@
 	 * @returns {NodeList}
 	 */
 	pf.qsa = function(context, sel) {
+		if ( !( "querySelector" in document ) ) {
+			return [];
+		}
 		return context.querySelectorAll(sel);
 	};
 


### PR DESCRIPTION
Prevents browsers without document.querySelectorAll support from throwing fatal errors.

