### PR TITLE
Feature detect document.querySelector

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -969,7 +969,7 @@
 	 * Can be extended with jQuery/Sizzle for IE7 support
 	 * @param context
 	 * @param sel
-	 * @returns {NodeList}
+	 * @returns {NodeList|Array}
 	 */
 	pf.qsa = function(context, sel) {
 		return ( "querySelector" in context ) ? context.querySelectorAll(sel) : [];

--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -972,7 +972,7 @@
 	 * @returns {NodeList}
 	 */
 	pf.qsa = function(context, sel) {
-		return context.querySelectorAll(sel);
+		return ( "querySelector" in context ) ? context.querySelectorAll(sel) : [];
 	};
 
 	/**


### PR DESCRIPTION
Prevents browsers without document.querySelectorAll support from throwing fatal errors.

Incorporates feedback in PR #606 and targets correct branch.

Updates docblock to note array can be returned.