### PR TITLE
s/wwwindow/www/

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -250,7 +250,7 @@
 	}
 
 	// test svg support
-	types[ "image/svg+xml" ] = document.implementation.hasFeature( "http://wwwindow.w3.org/TR/SVG11/feature#Image", "1.1" );
+	types[ "image/svg+xml" ] = document.implementation.hasFeature( "http://www.w3.org/TR/SVG11/feature#Image", "1.1" );
 
 	/**
 	 * updates the internal vW property with the current viewport width in px


### PR DESCRIPTION
I’m not an expert, but guessing that SVG’s namespace is http://www.w3.org/TR/SVG11/feature#Image, not http://www**indow**.w3.org/TR/SVG11/feature#Image.

According to standard `document.implementation.hasFeature` returns true for any value: https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature