### PR TITLE
Change download links to use tags instead of branches

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
 			<p>Feedback on this release is highly welcomed—if you encounter any problems, please <a href="https://github.com/scottjehl/picturefill/issues">file an issue on GitHub</a>.</p>
 			<ul>
 				<li>
-					<a href="https://cdn.rawgit.com/scottjehl/picturefill/master/dist/picturefill.js" class="download">picturefill.js</a>
+					<a href="https://cdn.rawgit.com/scottjehl/picturefill/3.0.2/dist/picturefill.js" class="download">picturefill.js</a>
 					<p class="meta">(development version, unminified code)</p>
 				</li>
 				<li>
-					<a href="https://cdn.rawgit.com/scottjehl/picturefill/master/dist/picturefill.min.js" class="download">picturefill.min.js</a>
+					<a href="https://cdn.rawgit.com/scottjehl/picturefill/3.0.2/dist/picturefill.min.js" class="download">picturefill.min.js</a>
 					<p class="meta">(production version, minified code)</p>
 				</li>
 			</ul>


### PR DESCRIPTION
Fixes #648. RawGit caches the results forever.