### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+examples
+gruntfile.js
+.jscsrc
+.jshintrc
+src
+tests
+logos
+.travis.yml


### PR DESCRIPTION
Currently, an install of this modules takes up ~18MB. Almost all of that is the examples/ directory. After adding a `.npmignore` file, an install of this module only takes up around 200KB.

You can check with, eg:
```
npm pack
tar xzvf picturefill-3.0.2.tgz
du -hs package
```