### PR TITLE
Typescript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node": ">= 0.8.0"
   },
   "main": "./dist/picturefill",
+  "types": "./src/picturefill.d.ts",
   "scripts": {
     "test": "grunt test --verbose"
   },

--- a/src/picturefill.d.ts
+++ b/src/picturefill.d.ts
@@ -1,0 +1,20 @@
+declare namespace Picturefill {
+  interface EvaluateArg {
+    // If you dynamically change the srcset, sizes attributes, or modify
+    // source elements, please use this reevaluate option
+    reevaluate?: boolean;
+
+    // An array of `img` elements you'd like Picturefill to evaluate.
+    elements: Array<Element> | NodeList;
+  }
+
+  interface Constructor {
+    (arg: EvaluateArg): void;
+  }
+}
+
+declare var picturefill: Picturefill.Constructor;
+
+declare module 'picturefill' {
+  export = picturefill;
+}


### PR DESCRIPTION
Only one global function `picturefill` is exported.

Note: `reselect` option was not declared, b/c it is undocumented.