### PR TITLE
docs: Fix simple typo, wether -> whether

### DIFF
--- a/src/picturefill.js
+++ b/src/picturefill.js
@@ -977,7 +977,7 @@
 
 	/**
 	 * Shortcut method for matchMedia ( for easy overriding in tests )
-	 * wether native or pf.mMQ is used will be decided lazy on first call
+	 * whether native or pf.mMQ is used will be decided lazy on first call
 	 * @returns {boolean}
 	 */
 	pf.matchesMedia = function() {


### PR DESCRIPTION
There is a small typo in src/picturefill.js.

Should read `whether` rather than `wether`.

